### PR TITLE
事業をエンジニアリングしよう ②実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,9 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'rb-readline'
   gem 'rspec-rails'
+  gem 'simplecov', require: false, group: :test
+  gem 'capybara'
+  gem 'selenium-webdriver'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,9 +106,20 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    capybara (3.38.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
+    childprocess (4.1.0)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     diff-lcs (1.4.4)
+    docile (1.4.0)
     draper (4.0.2)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -173,6 +184,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
+    matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.14.4)
@@ -181,6 +193,8 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.5.8)
+    nokogiri (1.12.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
@@ -284,6 +298,7 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
+    rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -294,7 +309,18 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    selenium-webdriver (4.6.1)
+      childprocess (>= 0.5, < 5.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     semantic_range (3.0.0)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sorcery (0.16.1)
       bcrypt (~> 3.1)
       oauth (~> 0.5, >= 0.5.5)
@@ -323,12 +349,16 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.5.1)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-19
   x86_64-linux
 
@@ -336,6 +366,7 @@ DEPENDENCIES
   aws-sdk-s3
   bootsnap (>= 1.4.4)
   byebug
+  capybara
   draper
   enum_help
   factory_bot_rails
@@ -356,6 +387,8 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   sass-rails (>= 6)
+  selenium-webdriver
+  simplecov
   sorcery
   spring
   sqlite3 (~> 1.4)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -60,6 +60,6 @@ class EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:event).permit(:title, :content, :held_at, :prefecture_id, :thumbnail)
+    params.require(:event).permit(:title, :content, :only_woman, :held_at, :prefecture_id, :thumbnail)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,6 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:email, :name, :password, :password_confirmation)
+    params.require(:user).permit(:email, :name, :gender, :password, :password_confirmation)
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,6 +20,8 @@ class Event < ApplicationRecord
     validates :held_at
   end
 
+  enum only_woman: { チェックあり: true, チェックなし: false }
+
   def past?
     held_at < Time.current
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,7 +20,7 @@ class Event < ApplicationRecord
     validates :held_at
   end
 
-  enum only_woman: { チェックあり: true, チェックなし: false }
+  enum only_woman: { 女性限定: true, 限定なし: false }
 
   def past?
     held_at < Time.current

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,8 @@ class User < ApplicationRecord
 
   validates :email, uniqueness: true
 
+  enum gender: { lgtm: 0, men: 1, women: 2 }
+
   scope :allowing_created_event_notification,
         -> { joins(:notification_timings).merge(NotificationTiming.created_event) }
   scope :allowing_commented_to_event_notification,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,7 @@ class User < ApplicationRecord
 
   validates :email, uniqueness: true
 
-  enum gender: { lgtm: 0, men: 1, women: 2 }
+  enum gender: { lgtm: 0, man: 1, woman: 2 }
 
   scope :allowing_created_event_notification,
         -> { joins(:notification_timings).merge(NotificationTiming.created_event) }

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -15,7 +15,7 @@
           <%= event.prefecture.name %>
         </div>
         <div>
-          <% if event.only_woman == "女性限定" %>
+          <% if event.only_woman? %>
             <%= event.only_woman_i18n %>
           <% end %>
         </div>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -15,6 +15,11 @@
           <%= event.prefecture.name %>
         </div>
         <div>
+          <% if event.only_woman == "女性限定" %>
+            <%= event.only_woman_i18n %>
+          <% end %>
+        </div>
+        <div>
           <i class="bi bi-calendar"></i>
           <%= l event.held_at, format: :short %>
         </div>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -18,7 +18,7 @@
   </div>
   <div class="mb-3">
     <%= f.label :only_woman %>
-    <%= f.check_box :only_woman %>
+    <%= f.check_box :only_woman, {}, "チェックあり", "チェックなし" %>
   </div>
   <div class="mb-3">
     <%= f.label :thumbnail %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -16,7 +16,7 @@
     <%= f.label :prefecture_id %>
     <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, {}, class: 'form-select' %>
   </div>
-  <% if current_user.gender == "women" %>
+  <% if current_user.gender == "woman" %>
     <div class="mb-3">
       <%= f.label :only_woman %>
       <%= f.check_box :only_woman, {}, "女性限定", "限定なし" %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -17,6 +17,10 @@
     <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, {}, class: 'form-select' %>
   </div>
   <div class="mb-3">
+    <%= f.label :only_woman %>
+    <%= f.check_box :only_woman %>
+  </div>
+  <div class="mb-3">
     <%= f.label :thumbnail %>
     <%= f.file_field :thumbnail, class: 'form-control js-file-select-preview mb-3', accept: 'image/*', data: { target: '#preview-target' } %>
     <%= image_tag f.object.decorate.thumbnail, id: 'preview-target', class: 'w-100 border' %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -16,10 +16,12 @@
     <%= f.label :prefecture_id %>
     <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, {}, class: 'form-select' %>
   </div>
-  <div class="mb-3">
-    <%= f.label :only_woman %>
-    <%= f.check_box :only_woman, {}, "チェックあり", "チェックなし" %>
-  </div>
+  <% if current_user.gender == "women" %>
+    <div class="mb-3">
+      <%= f.label :only_woman %>
+      <%= f.check_box :only_woman, {}, "女性限定", "限定なし" %>
+    </div>
+  <% end %>
   <div class="mb-3">
     <%= f.label :thumbnail %>
     <%= f.file_field :thumbnail, class: 'form-control js-file-select-preview mb-3', accept: 'image/*', data: { target: '#preview-target' } %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -45,6 +45,9 @@
         </div>
         <div class="card-body">
           <%= simple_format @event.content %>
+          <% if @event.only_woman == "女性限定" %>
+            <%= @event.only_woman_i18n %>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -45,7 +45,7 @@
         </div>
         <div class="card-body">
           <%= simple_format @event.content %>
-          <% if @event.only_woman == "女性限定" %>
+          <% if @event.only_woman? %>
             <%= @event.only_woman_i18n %>
           <% end %>
         </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -96,8 +96,8 @@
                               data: { confirm: 'キャンセルします' }
                   %>
                 <% else %>
-                  <% if @event.only_woman == "女性限定" %>
-                    <% if current_user.gender == "woman" %>
+                  <% if @event.only_woman? %>
+                    <% if current_user.woman? %>
                       <%= link_to 'このもくもく会に参加する',
                                   event_attendance_url(@event),
                                   class: 'btn btn-primary',

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -96,12 +96,23 @@
                               data: { confirm: 'キャンセルします' }
                   %>
                 <% else %>
-                  <%= link_to 'このもくもく会に参加する',
-                              event_attendance_url(@event),
-                              class: 'btn btn-primary',
-                              method: :post,
-                              data: { confirm: '申し込みます' }
-                  %>
+                  <% if @event.only_woman == "女性限定" %>
+                    <% if current_user.gender == "woman" %>
+                      <%= link_to 'このもくもく会に参加する',
+                                  event_attendance_url(@event),
+                                  class: 'btn btn-primary',
+                                  method: :post,
+                                  data: { confirm: '申し込みます' }
+                      %>
+                    <% end %>
+                  <% else %>
+                    <%= link_to 'このもくもく会に参加する',
+                                event_attendance_url(@event),
+                                class: 'btn btn-primary',
+                                method: :post,
+                                data: { confirm: '申し込みます' }
+                    %>
+                  <% end %>
                 <% end %>
               <% end %>
             <% end %>

--- a/app/views/mypage/shared/_user_info.html.erb
+++ b/app/views/mypage/shared/_user_info.html.erb
@@ -16,6 +16,7 @@
             <%= current_user.name %>
           </h2>
           <p class="mb-0 d-block"><%= current_user.email %></p>
+          <p><%= current_user.gender_i18n %></p>
         </div>
       </div>
     </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -24,6 +24,10 @@
               <%= f.email_field :email, class: 'form-control' %>
             </div>
             <div class="mb-3">
+              <%= f.label :gender %>
+              <%= f.select :gender, User.genders_i18n.invert, {}, class: 'form-control' %>
+            </div>
+            <div class="mb-3">
               <%= f.label :password %>
               <%= f.password_field :password, class: 'form-control' %>
             </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,3 +6,8 @@ ja:
         commented_to_event: あなたのイベントにコメントがあった時
         attended_to_event: あなたのイベントに参加申し込みがあった時
         liked_event: あなたのイベントにいいねがついた時
+    user:
+      gender:
+        lgtm: "LGTM"
+        men: "男性"
+        women: "女性"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,5 +9,5 @@ ja:
     user:
       gender:
         lgtm: "LGTM"
-        men: "男性"
-        women: "女性"
+        man: "男性"
+        woman: "女性"

--- a/db/migrate/20221024130840_add_gender_to_users.rb
+++ b/db/migrate/20221024130840_add_gender_to_users.rb
@@ -1,0 +1,5 @@
+class AddGenderToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :gender, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20221024142305_add_only_woman_to_events.rb
+++ b/db/migrate/20221024142305_add_only_woman_to_events.rb
@@ -1,0 +1,5 @@
+class AddOnlyWomanToEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :events, :only_woman, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_19_072358) do
+ActiveRecord::Schema.define(version: 2022_10_24_130840) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -135,6 +135,7 @@ ActiveRecord::Schema.define(version: 2022_01_19_072358) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "gender", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_24_130840) do
+ActiveRecord::Schema.define(version: 2022_10_24_142305) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 2022_10_24_130840) do
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "only_woman"
     t.index ["prefecture_id"], name: "index_events_on_prefecture_id"
     t.index ["user_id"], name: "index_events_on_user_id"
   end


### PR DESCRIPTION
【実装内容】
- ユーザー登録時に手入力やチェックボックス入力ではなく、セレクト形式で性別登録できる。
- イベント作成画面にOnly womanのチェックボックスにチェックを入れるだけで女性限定イベントを作できる。
- ユーザーが女性以外の場合、イベント作成時にOnly womanは表示されず、女性限定イベントが作成できない。
- 女性限定イベントには女性のみが参加できる。
- 女性以外の場合、女性限定イベントの詳細ページを開いた際に「このもくもく会に参加する」が表示されない。
- 女性限定イベントは一覧・詳細画面にて「女性限定」が表記される。
![mokumoku_spec](https://user-images.githubusercontent.com/102616360/200331657-97ecc705-b3ef-4d6f-ba74-f52912e4147e.png)
